### PR TITLE
Use API for getting extension configuration for TYPO3 v9+

### DIFF
--- a/Classes/Service/Configuration.php
+++ b/Classes/Service/Configuration.php
@@ -3,7 +3,10 @@ declare(strict_types=1);
 
 namespace Plan2net\Webp\Service;
 
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 
 /**
  * Class Configuration
@@ -26,8 +29,12 @@ class Configuration implements SingletonInterface
      */
     public static function get($key = null)
     {
-        if (empty(self::$configuration) && isset($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['webp'])) {
-            self::$configuration = (array)unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['webp']);
+        if (VersionNumberUtility::convertVersionStringToArray(VersionNumberUtility::getCurrentTypo3Version())['version_main'] < 9) {
+            if (empty(self::$configuration) && isset($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['webp'])) {
+                self::$configuration = (array)unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['webp']);
+            }
+        } else {
+            self::$configuration = (array)GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('webp');
         }
 
         if (!empty($key)) {


### PR DESCRIPTION
In TYPO3 v9 a new API for retrieving the extension configuration was introduced:

https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.0/Deprecation-82254-DeprecateGLOBALSTYPO3_CONF_VARSEXTextConf.html

This patch uses this API for TYPO3 v9+