### PR TITLE
[TASK] do not try to process missing files

### DIFF
--- a/Classes/Converter/MagickConverter.php
+++ b/Classes/Converter/MagickConverter.php
@@ -33,6 +33,10 @@ class MagickConverter implements Converter
      */
     public function convert(string $originalFilePath, string $targetFilePath): void
     {
+        if (!is_file($originalFilePath)) {
+            return;
+        }
+
         $result = $this->getGraphicalFunctionsObject()->imageMagickExec(
             $originalFilePath,
             $targetFilePath,


### PR DESCRIPTION
It happens, that files are removed from filesystem. Thus sys_file/sys_file_reference remain with a "missing"-flag.
Early exit if file is not available anymore.
Use "is_file" rather than "file_exists". It is the right choice here (and faster too) as symlinks on file-storages are not common at all.