### PR TITLE
[TASK] Specify extension key in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,10 @@
     "psr-4": {
       "Plan2net\\Webp\\": "Classes/"
     }
-  }
+  },
+	"extra": {
+		"typo3/cms": {
+			"extension-key": "webp"
+		}
+	}
 }


### PR DESCRIPTION
Specifying the extension key will be mandatory in future versions of TYPO3.

See:
https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra