### PR TITLE
[TASK] Add extension to to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,10 @@
     "psr-4": {
       "Plan2net\\Webp\\": "Classes/"
     }
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "webp"
+    }
   }
 }


### PR DESCRIPTION
TYPO3 Extension Package "plan2net/webp", does not define extension key in composer.json.
Specifying the extension key will be mandatory in future versions of TYPO3 (see: https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra)