### PR TITLE
Replace deprecated "GeneralUtility::shortMD5" function

### DIFF
--- a/Classes/EventListener/AfterFileProcessing.php
+++ b/Classes/EventListener/AfterFileProcessing.php
@@ -85,8 +85,16 @@ class AfterFileProcessing
                 // but TYPO3 CMS core has a limit on this field
                 $processedFileWebp->updateProperties(
                     [
-                        'checksum' => GeneralUtility::shortMD5(implode('|',
-                            $this->getChecksumData($file, $processedFileWebp, $configuration)))
+                        'checksum' => substr(
+                            md5(
+                                implode(
+                                    '|',
+                                    $this->getChecksumData($file, $processedFileWebp, $configuration)
+                                )
+                            ),
+                            0,
+                            10
+                        );
                     ]
                 );
 

--- a/Classes/EventListener/AfterFileProcessing.php
+++ b/Classes/EventListener/AfterFileProcessing.php
@@ -94,7 +94,7 @@ class AfterFileProcessing
                             ),
                             0,
                             10
-                        );
+                        ),
                     ]
                 );
 


### PR DESCRIPTION
As of https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.4/Deprecation-94684-GeneralUtilityShortMD5.html the Utility "GeneralUtility::shortMD5" has been deprecated and will be replaced with the native counterpart.