### PR TITLE
[BUGFIX] Avoid trying to process webp images

### DIFF
--- a/Classes/Service/Webp.php
+++ b/Classes/Service/Webp.php
@@ -36,6 +36,9 @@ class Webp
      */
     public function process(FileInterface $originalFile, ProcessedFile $processedFile): void
     {
+        if ($originalFile->getExtension() === 'webp') {
+            return;
+        }
         $processedFile->setName($originalFile->getName() . '.webp');
         $processedFile->setIdentifier($originalFile->getIdentifier() . '.webp');
 


### PR DESCRIPTION
If the original file is already webp, there is no need to process it.
Without the check, the logfile gets bloated.