### PR TITLE
Update FileNameFilter.php

### DIFF
--- a/Classes/Core/Filter/FileNameFilter.php
+++ b/Classes/Core/Filter/FileNameFilter.php
@@ -26,7 +26,13 @@ class FileNameFilter
         DriverInterface $driverInstance
     ): int {
         if (strpos($itemIdentifier, '.webp') === strlen($itemIdentifier) - 5) {
-            return -1;
+            if (false !== strpos($itemIdentifier, '.gif.webp')
+                || false !== strpos($itemIdentifier, '.jpg.webp')
+                || false !== strpos($itemIdentifier, '.jpeg.webp')
+                || false !== strpos($itemIdentifier, '.png.webp')
+            ) {
+                return -1;
+            }
         }
 
         return 1;


### PR DESCRIPTION
Only filter out file names if they look like converted files, e.g. .jpg.webp, but not if the file seems to be an original .webp.