### PR TITLE
[BUGFIX] Change executeQuery to executeStatement to fix QueryBuilder …

### DIFF
--- a/Classes/Service/Webp.php
+++ b/Classes/Service/Webp.php
@@ -106,7 +106,7 @@ final class Webp
                 'configuration' => $configuration,
                 'configuration_hash' => md5($configuration),
             ])
-            ->executeQuery();
+            ->executeStatement();
     }
 
     private function hasFailedAttempt(int $fileId, string $configuration): bool


### PR DESCRIPTION
After I installed the new webp version on a TYPO3 12 system, I've got a error in QueryBuilder (Cannot access offset of type string on string) caused by the executeQuery function.