### PR TITLE
Filter generated webp files only

### DIFF
--- a/Classes/Core/Filter/FileNameFilter.php
+++ b/Classes/Core/Filter/FileNameFilter.php
@@ -9,7 +9,8 @@ use TYPO3\CMS\Core\Resource\Driver\DriverInterface;
 final class FileNameFilter
 {
     /**
-     * Remove webp files from file lists.
+     * Remove generated webp files from file lists,
+     * i.e. files that end in .suffix.webp, but not .webp solely.
      */
     public static function filterWebpFiles(
         string $itemName,
@@ -18,7 +19,7 @@ final class FileNameFilter
         array $additionalInformation,
         DriverInterface $driverInstance
     ): int {
-        if (\strpos($itemIdentifier, '.webp') === \strlen($itemIdentifier) - 5) {
+        if (preg_match('/\.[^\.]*\.webp$/', $itemIdentifier) === 1) {
             return -1;
         }
 

--- a/Classes/Core/Filter/FileNameFilter.php
+++ b/Classes/Core/Filter/FileNameFilter.php
@@ -19,7 +19,7 @@ final class FileNameFilter
         array $additionalInformation,
         DriverInterface $driverInstance
     ): int {
-        if (preg_match('/\.[^\.]*\.webp$/', $itemIdentifier) === 1) {
+        if (preg_match('/\.[^\.]+\.webp$/', $itemIdentifier) === 1) {
             return -1;
         }
 

--- a/Classes/Core/Filter/FileNameFilter.php
+++ b/Classes/Core/Filter/FileNameFilter.php
@@ -19,7 +19,7 @@ final class FileNameFilter
         array $additionalInformation,
         DriverInterface $driverInstance
     ): int {
-        if (preg_match('/\.[^\.]+\.webp$/', $itemIdentifier) === 1) {
+        if (1 === \preg_match('/\.[^\.]+\.webp$/', $itemIdentifier)) {
             return -1;
         }
 


### PR DESCRIPTION
This changes the filtering behaviour for file lists, so that it only filters generated webp files, but not regular, user submitted ones. These are distinguished by checking for a preceding file suffix before the ".webp".

Edit: @plan2net If you decide to merge this, please consider squashing the commits.