### PR TITLE
[BUGFIX] Handle hardened GFX processor_stripColorProfileCommand

### DIFF
--- a/Classes/Converter/MagickConverter.php
+++ b/Classes/Converter/MagickConverter.php
@@ -6,6 +6,7 @@ namespace Plan2net\Webp\Converter;
 
 use Plan2net\Webp\Service\Configuration;
 use TYPO3\CMS\Core\Imaging\GraphicalFunctions;
+use TYPO3\CMS\Core\Utility\CommandUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -17,7 +18,7 @@ final class MagickConverter extends AbstractConverter
     {
         $parameters = $this->parameters;
         if (Configuration::get('use_system_settings')) {
-            $parameters .= ' ' . $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_stripColorProfileCommand'];
+            $parameters .= ' ' . $this->parseStripColorProfileCommand();
             $parameters = trim($parameters);
         }
 
@@ -42,5 +43,20 @@ final class MagickConverter extends AbstractConverter
         }
 
         return $graphicalFunctionsObject;
+    }
+
+    /**
+     * @see https://typo3.org/security/advisory/typo3-core-sa-2024-002
+     */
+    private function parseStripColorProfileCommand(): mixed
+    {
+        return $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_stripColorProfileCommand'] ??
+            implode(
+                ' ',
+                array_map(
+                    CommandUtility::escapeShellArgument(...),
+                    $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_stripColorProfileParameters'] ?? [],
+                ),
+            );
     }
 }

--- a/Classes/Converter/MagickConverter.php
+++ b/Classes/Converter/MagickConverter.php
@@ -48,10 +48,13 @@ final class MagickConverter extends AbstractConverter
     /**
      * @see https://typo3.org/security/advisory/typo3-core-sa-2024-002
      */
-    private function parseStripColorProfileCommand(): mixed
+    private function parseStripColorProfileCommand(): string
     {
-        return $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_stripColorProfileCommand'] ??
-            implode(
+        if (is_string($GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_stripColorProfileCommand'] ?? null)) {
+            return $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_stripColorProfileCommand'];
+        }
+
+        return implode(
                 ' ',
                 array_map(
                     CommandUtility::escapeShellArgument(...),

--- a/README.md
+++ b/README.md
@@ -116,11 +116,12 @@ Example value: `/fileadmin/demo/special;/another-storage/demo/exclusive`
 
 ### `use_system_settings`
 
-    # cat=basic; type=boolean; label=Use the system GFX "processor_stripColorProfileCommand" setting for the MagickConverter converter
+    # cat=basic; type=boolean; label=Use the system GFX "processor_stripColorProfileCommand"/"processor_stripColorProfileParameters" setting for the MagickConverter converter
     use_system_settings = 1
 
-When set (default) the value from `$GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_stripColorProfileCommand']` is appended 
-automatically to the configuration options for the `MagickConverter` converter, so you don't need to repeat the settings.
+When set (default) the value from `$GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_stripColorProfileCommand']` or
+`$GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_stripColorProfileParameters']` is appended automatically to the
+configuration options for the `MagickConverter` converter, so you don't need to repeat the settings.
 
 ## Webserver example configuration
 

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -10,7 +10,7 @@ silent = 0
 mime_types = image/jpeg,image/png,image/gif
 # cat=basic; type=string; label=Exclude processing of images from specific directories (separated by semicolon)
 exclude_directories =
-# cat=basic; type=boolean; label=Use the system GFX "processor_stripColorProfileCommand" setting for the MagickConverter converter
+# cat=basic; type=boolean; label=Use the system GFX "processor_stripColorProfileCommand"/"processor_stripColorProfileParameters" setting for the MagickConverter converter
 use_system_settings = 1
 # cat=basic; type=boolean; label=Hide .webp files matching the below pattern in backend file list module
 hide_webp = 1


### PR DESCRIPTION
With [TYPO3-CORE-SA-2024-002](https://typo3.org/security/advisory/typo3-core-sa-2024-002), the previously used configuration option `$GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_stripColorProfileCommand']` was replaced by a new configuration option `$GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_stripColorProfileParameters']` which provides an array instead of a string. This PR  adapt the codebase in `MagickConverter` to use the new configuration option, but stays compatible with legacy configurations.

Resolves: #92