### PR TITLE
[BUGFIX] if basePath is not defined, assume empty string

### DIFF
--- a/Classes/EventListener/AfterFileProcessing.php
+++ b/Classes/EventListener/AfterFileProcessing.php
@@ -155,7 +155,7 @@ final class AfterFileProcessing
 
     private function originalFileIsInExcludedDirectory(FileInterface $file): bool
     {
-        $storageBasePath = $file->getStorage()->getConfiguration()['basePath'];
+        $storageBasePath = $file->getStorage()->getConfiguration()['basePath'] ?? '';
         $filePath = rtrim($storageBasePath, '/') . '/' . ltrim($file->getIdentifier(), '/');
         $excludeDirectories = array_filter(explode(';', Configuration::get('exclude_directories')));
 


### PR DESCRIPTION
Some drivers like fal_s3 don't define basePath in the flexform (They require processConfigt to be called). 
I was unable to get this working by patching fal_s3. 
Still, if the array key "basePath" is not declared, it shoud be concidered to be an empty string and not cause the website to crash.