### PR TITLE
[BUGFIX] Avoid PostgreSQL duplicate queue insert errors

### DIFF
--- a/Classes/Domain/Queue/ConversionQueueRepository.php
+++ b/Classes/Domain/Queue/ConversionQueueRepository.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace Plan2net\Webp\Domain\Queue;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Plan2net\Webp\Format\OutputFormat;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 
 final readonly class ConversionQueueRepository
 {
     private const TABLE = 'tx_webp_queue';
+    private const DEDUP_COLUMNS = ['original_file_id', 'processed_file_id', 'task_type', 'configuration_hash', 'format'];
 
     public function __construct(
         private ConnectionPool $connectionPool,
@@ -24,29 +27,66 @@ final readonly class ConversionQueueRepository
         $now = \time();
 
         $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
+        $row = [
+            'original_file_id' => $originalFileId,
+            'processed_file_id' => $processedFileId,
+            'task_type' => $taskType,
+            'configuration' => $serialized,
+            'configuration_hash' => $hash,
+            'enqueued_at' => $now,
+            'format' => $format->value,
+        ];
+
+        if ($connection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+            $this->upsertPostgreSql($connection, $row);
+
+            return;
+        }
+
         try {
-            $connection->insert(self::TABLE, [
-                'original_file_id' => $originalFileId,
-                'processed_file_id' => $processedFileId,
-                'task_type' => $taskType,
-                'configuration' => $serialized,
-                'configuration_hash' => $hash,
-                'enqueued_at' => $now,
-                'format' => $format->value,
-            ]);
+            $connection->insert(self::TABLE, $row);
         } catch (UniqueConstraintViolationException) {
             $connection->update(
                 self::TABLE,
-                ['enqueued_at' => $now],
-                [
-                    'original_file_id' => $originalFileId,
-                    'processed_file_id' => $processedFileId,
-                    'task_type' => $taskType,
-                    'configuration_hash' => $hash,
-                    'format' => $format->value,
-                ]
+                ['enqueued_at' => $row['enqueued_at']],
+                $this->dedupCriteria($row)
             );
         }
+    }
+
+    /**
+     * PostgreSQL logs every failed INSERT before DBAL can catch the unique constraint
+     * exception, so duplicate queue entries must be handled with a native upsert.
+     *
+     * @param array<string, int|string> $row
+     */
+    private function upsertPostgreSql(Connection $connection, array $row): void
+    {
+        $platform = $connection->getDatabasePlatform();
+        $columns = \array_keys($row);
+
+        $connection->executeStatement(
+            \sprintf(
+                'INSERT INTO %s (%s) VALUES (%s) ON CONFLICT (%s) DO UPDATE SET %s = EXCLUDED.%s',
+                $platform->quoteSingleIdentifier(self::TABLE),
+                \implode(', ', \array_map($platform->quoteSingleIdentifier(...), $columns)),
+                \implode(', ', \array_fill(0, \count($columns), '?')),
+                \implode(', ', \array_map($platform->quoteSingleIdentifier(...), self::DEDUP_COLUMNS)),
+                $platform->quoteSingleIdentifier('enqueued_at'),
+                $platform->quoteSingleIdentifier('enqueued_at'),
+            ),
+            \array_values($row),
+        );
+    }
+
+    /**
+     * @param array<string, int|string> $row
+     *
+     * @return array<string, int|string>
+     */
+    private function dedupCriteria(array $row): array
+    {
+        return \array_intersect_key($row, \array_flip(self::DEDUP_COLUMNS));
     }
 
     /**

--- a/Tests/Unit/Domain/Queue/ConversionQueueRepositoryTest.php
+++ b/Tests/Unit/Domain/Queue/ConversionQueueRepositoryTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Plan2net\Webp\Tests\Unit\Domain\Queue;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Plan2net\Webp\Domain\Queue\ConversionQueueRepository;
+use Plan2net\Webp\Format\OutputFormat;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+final class ConversionQueueRepositoryTest extends TestCase
+{
+    #[Test]
+    public function enqueueOnPostgreSqlEmitsNativeUpsertInsteadOfInsert(): void
+    {
+        $capturedSql = null;
+        $capturedParameters = null;
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getDatabasePlatform')->willReturn(new PostgreSQLPlatform());
+        $connection->expects(self::never())->method('insert');
+        $connection->expects(self::once())
+            ->method('executeStatement')
+            ->willReturnCallback(static function (string $sql, array $parameters) use (&$capturedSql, &$capturedParameters): int {
+                $capturedSql = $sql;
+                $capturedParameters = $parameters;
+
+                return 1;
+            });
+
+        $this->repositoryFor($connection)->enqueue(42, 7, 'Image.CropScaleMask', ['width' => 100], OutputFormat::Webp);
+
+        $expectedSql = 'INSERT INTO "tx_webp_queue" '
+            . '("original_file_id", "processed_file_id", "task_type", "configuration", "configuration_hash", "enqueued_at", "format") '
+            . 'VALUES (?, ?, ?, ?, ?, ?, ?) '
+            . 'ON CONFLICT ("original_file_id", "processed_file_id", "task_type", "configuration_hash", "format") '
+            . 'DO UPDATE SET "enqueued_at" = EXCLUDED."enqueued_at"';
+        self::assertSame($expectedSql, $capturedSql);
+
+        $serialized = \serialize(['width' => 100]);
+        self::assertSame(42, $capturedParameters[0]);
+        self::assertSame(7, $capturedParameters[1]);
+        self::assertSame('Image.CropScaleMask', $capturedParameters[2]);
+        self::assertSame($serialized, $capturedParameters[3]);
+        self::assertSame(\md5($serialized), $capturedParameters[4]);
+        self::assertIsInt($capturedParameters[5]);
+        self::assertSame('webp', $capturedParameters[6]);
+    }
+
+    #[Test]
+    public function enqueueOnNonPostgreSqlPlatformUsesInsert(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getDatabasePlatform')->willReturn($this->createMock(AbstractPlatform::class));
+        $connection->expects(self::never())->method('executeStatement');
+        $connection->expects(self::once())
+            ->method('insert')
+            ->with(
+                'tx_webp_queue',
+                self::callback(static function (array $row): bool {
+                    return 42 === $row['original_file_id']
+                        && 7 === $row['processed_file_id']
+                        && 'Image.CropScaleMask' === $row['task_type']
+                        && 'webp' === $row['format'];
+                })
+            );
+
+        $this->repositoryFor($connection)->enqueue(42, 7, 'Image.CropScaleMask', ['width' => 100], OutputFormat::Webp);
+    }
+
+    private function repositoryFor(Connection $connection): ConversionQueueRepository
+    {
+        $connectionPool = $this->createMock(ConnectionPool::class);
+        $connectionPool->method('getConnectionForTable')->with('tx_webp_queue')->willReturn($connection);
+
+        return new ConversionQueueRepository($connectionPool);
+    }
+}


### PR DESCRIPTION
Fixes #118.

## What changed

`ConversionQueueRepository::enqueue()` now uses a native PostgreSQL upsert for `tx_webp_queue` when the active DBAL platform is PostgreSQL.

The existing insert/catch/update fallback remains in place for other database platforms.

## Why

The previous code was functionally idempotent for the application, but PostgreSQL still logged every duplicate insert as an `ERROR` before DBAL converted it to `UniqueConstraintViolationException`. On busy async installations this can produce a large amount of database log output even though the application handles the duplicate afterwards.

The PostgreSQL path now inserts the queue row or refreshes `enqueued_at` via `ON CONFLICT`, so duplicate queue entries do not become failed statements in PostgreSQL.

## Checks

- `php -l Classes/Domain/Queue/ConversionQueueRepository.php`
- `.Build/bin/phpunit -c phpunit-functional.xml Tests/Functional/Domain/Queue/ConversionQueueRepositoryTest.php`
- `PHP_CS_FIXER_IGNORE_ENV=1 .Build/bin/php-cs-fixer fix --dry-run --diff --config=php-cs-fixer.config.php Classes/Domain/Queue/ConversionQueueRepository.php`
- `.Build/bin/phpstan analyse Classes/Domain/Queue/ConversionQueueRepository.php --configuration=phpstan.neon --no-progress`

Note: I ran these in a disposable Composer/PHP container. The container PHP did not include `ext-intl`, so Composer dependencies were installed with `--ignore-platform-req=ext-intl`; the focused tests above passed.